### PR TITLE
using Sets to create an array of unique values

### DIFF
--- a/src/components/SelectedShowContainer.js
+++ b/src/components/SelectedShowContainer.js
@@ -6,7 +6,7 @@ function SelectedShowContainer(props) {
 
   function mapSeasons() {
     if (!!props.episodes) {
-      let seasons = props.episodes.map((e) => e.season).unique();
+      let seasons = [...Set(props.episodes.map((e) => e.season))];
 
       return seasons.map((s) => {
         return (
@@ -49,13 +49,3 @@ function SelectedShowContainer(props) {
 }
 
 export SelectedShowContainer;
-
-Array.prototype.unique = function () {
-  const arr = [];
-  for (let i = 0; i < this.length; i++) {
-    if (!arr.includes(this[i])) {
-      arr.push(this[i]);
-    }
-  }
-  return arr;
-};


### PR DESCRIPTION
Using Sets instead of unique() function as a new Array's prototype, which gives an Array prototype is read-only warning in some browsers such as Chrome since Extending prototype of a native object in javascript is considered as a bad practice. 
It may causes problems in old browsers. 
ref: [extending native](https://github.com/jamesallardice/jslint-error-explanations/blob/master/message-articles/extending-native.md) 